### PR TITLE
Location support for constructors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ sealed_test = "1"
 
 [features]
 backtrace = ["thiserror-ext-derive/backtrace"]
+location = ["thiserror-ext-derive/location"]
 
 [workspace]
 members = ["derive"]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 
 [features]
 backtrace = []
+location = []
 
 [dependencies]
 either = "1"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -42,6 +42,14 @@ mod thiserror;
 ///
 /// [`thiserror_ext::Box`]: derive@Box
 /// [`thiserror_ext::Arc`]: derive@Arc
+///
+/// # Location support
+///
+/// If you enable the `location` feature, and then create a parameter which has a
+/// type of [`&'static std::panic::Location<'static>`], then the location of the
+/// constructor call will be placed into that parameter.
+///
+/// [`&'static std::panic::Location<'static>`]: https://doc.rust-lang.org/stable/std/panic/struct.Location.html
 #[proc_macro_derive(Construct, attributes(thiserror_ext, construct))]
 pub fn derive_construct(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/derive/src/thiserror/props.rs
+++ b/derive/src/thiserror/props.rs
@@ -79,6 +79,10 @@ impl Field<'_> {
         type_is_backtrace(self.ty)
     }
 
+    pub(crate) fn is_location(&self) -> bool {
+        type_is_location(self.ty)
+    }
+
     /// Whether this field is the `source` field but not the `from` field.
     ///
     /// See [`Variant::source_field`].
@@ -178,4 +182,26 @@ fn type_is_backtrace(ty: &Type) -> bool {
 
     let last = path.segments.last().unwrap();
     last.ident == "Backtrace" && last.arguments.is_empty()
+}
+
+fn type_is_location(ty: &Type) -> bool {
+    let (lifetime, elem) = match ty {
+        Type::Reference(ty) => (&ty.lifetime, &ty.elem),
+        _ => return false,
+    };
+
+    if let Some(lifetime) = lifetime {
+        if lifetime.ident.to_string() != "static" {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    if let Type::Path(path) = elem.as_ref() {
+        let last = path.path.segments.last().unwrap();
+        last.ident == "Location"
+    } else {
+        false
+    }
 }


### PR DESCRIPTION
Allows callsites to be transparently captured for all errors.