### PR TITLE
Fix: specify either = 1.7 (earlier versions don't have for_both)

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -17,7 +17,7 @@ backtrace = ["provide"]
 provide = []
 
 [dependencies]
-either = "1"
+either = "1.7"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"


### PR DESCRIPTION
thiserror-ext uses the for_both macro that was only added in either 1.7, specifying only "1" in the cargo.toml can therefore cause build errors.